### PR TITLE
fix redirection to /bridge from landingpage

### DIFF
--- a/src/actions/RouterActions.js
+++ b/src/actions/RouterActions.js
@@ -152,7 +152,8 @@ export const getValidUrl = (action: RouterAction): PayloadAction<string> => (dis
     const shouldBeLandingPage = getState().devices.length < 1 || !getState().wallet.ready || getState().connect.error !== null;
     const landingPageUrl = dispatch(isLandingPageUrl(requestedUrl));
     if (shouldBeLandingPage) {
-        return !landingPageUrl ? '/' : requestedUrl;
+        const landingPageRoute = dispatch(isLandingPageUrl(requestedUrl, true));
+        return !landingPageRoute ? '/' : requestedUrl;
     }
 
     // Disallow displaying landing page
@@ -283,10 +284,16 @@ const goto = (url: string): ThunkAction => (dispatch: Dispatch, getState: GetSta
 /*
 * Check if requested OR current url is landing page
 */
-export const isLandingPageUrl = ($url?: string): PayloadAction<boolean> => (dispatch: Dispatch, getState: GetState): boolean => {
+export const isLandingPageUrl = ($url?: string, checkRoutes: boolean = false): PayloadAction<boolean> => (dispatch: Dispatch, getState: GetState): boolean => {
     let url: ?string = $url;
     if (typeof url !== 'string') {
         url = getState().router.location.pathname;
+    }
+    if (checkRoutes) {
+        const isLandingRoute = routes.find(r => r.pattern === url && r.name.indexOf('landing') >= 0);
+        if (isLandingRoute) {
+            return true;
+        }
     }
     return url === '/';
 };
@@ -334,7 +341,7 @@ export const gotoFirmwareUpdate = (): ThunkAction => (dispatch: Dispatch, getSta
 */
 export const setInitialUrl = (): PayloadAction<boolean> => (dispatch: Dispatch, getState: GetState): boolean => {
     const { initialPathname } = getState().wallet;
-    if (typeof initialPathname === 'string' && !dispatch(isLandingPageUrl(initialPathname))) {
+    if (typeof initialPathname === 'string' && !dispatch(isLandingPageUrl(initialPathname, true))) {
         const valid = dispatch(getValidUrl({
             type: LOCATION_CHANGE,
             payload: {

--- a/src/views/Landing/components/InstallBridge/index.js
+++ b/src/views/Landing/components/InstallBridge/index.js
@@ -131,7 +131,7 @@ class InstallBridge extends Component<Props, State> {
 
         const currentTarget: ?InstallTarget = installers.find(i => i.preferred === true);
         this.state = {
-            currentVersion: props.transport.type ? `Your version ${props.transport.version}` : 'Not installed',
+            currentVersion: props.transport.type && props.transport.type === 'bridge' ? `Your version ${props.transport.version}` : 'Not installed',
             latestVersion: props.transport.bridge.version.join('.'),
             installers,
             target: currentTarget || installers[0],

--- a/src/views/Landing/index.js
+++ b/src/views/Landing/index.js
@@ -106,7 +106,7 @@ export default (props: Props) => {
                         {shouldShowUnsupportedBrowser && <BrowserNotSupported />}
                         {shouldShowInstallBridge && <InstallBridge selectFirstAvailableDevice={props.selectFirstAvailableDevice} transport={transport} />}
 
-                        {(shouldShowConnectDevice || shouldShowDisconnectDevice) && (
+                        {!shouldShowInstallBridge && (shouldShowConnectDevice || shouldShowDisconnectDevice) && (
                             <div>
                                 <TitleWrapper>
                                     <H2 claim>The private bank in your hands.</H2>


### PR DESCRIPTION
- allows to redirect from / to /bridge route
- fix current bridge version if transport is webusb
- RouterActions optionally verifies if requested url has "landing" prefix in ./support/routes

partially fix for: #157