### PR TITLE
token existence validation

### DIFF
--- a/src/actions/SendFormActions.js
+++ b/src/actions/SendFormActions.js
@@ -90,8 +90,20 @@ export const observe = (prevState: ReducersState, action: Action): ThunkAction =
     let shouldUpdate: boolean = false;
     // check if "selectedAccount" reducer changed
     shouldUpdate = reducerUtils.observeChanges(prevState.selectedAccount, currentState.selectedAccount, {
-        account: ['balance', 'nonce'],
+        account: ['balance', 'nonce', 'tokens'],
     });
+    if (shouldUpdate && currentState.sendForm.currency !== currentState.sendForm.networkSymbol) {
+        // make sure that this token is added into account
+        const { account, tokens } = getState().selectedAccount;
+        if (!account) return;
+        const token = findToken(tokens, account.address, currentState.sendForm.currency, account.deviceState);
+        if (!token) {
+            // token not found, re-init form
+            dispatch(init());
+            return;
+        }
+    }
+
 
     // check if "sendForm" reducer changed
     if (!shouldUpdate) {

--- a/src/actions/SessionStorageActions.js
+++ b/src/actions/SessionStorageActions.js
@@ -1,5 +1,6 @@
 /* @flow */
 import * as storageUtils from 'utils/storage';
+import { findToken } from 'reducers/TokensReducer';
 
 import type { State as SendFormState } from 'reducers/SendFormReducer';
 import type {
@@ -37,6 +38,16 @@ export const loadDraftTransaction = (): PayloadAction<?SendFormState> => (dispat
     if (Object.keys(state.errors).length > 0) {
         storageUtils.remove(TYPE, key);
         return null;
+    }
+    // check if selected currency is token and make sure that this token is added into account
+    if (state.currency !== state.networkSymbol) {
+        const { account, tokens } = getState().selectedAccount;
+        if (!account) return null;
+        const token = findToken(tokens, account.address, state.currency, account.deviceState);
+        if (!token) {
+            storageUtils.remove(TYPE, key);
+            return null;
+        }
     }
     return state;
 };


### PR DESCRIPTION
Validation if selected token in send form is still assigned to seleted account.

This should fix below example:

1. goto summary, add token
2. goto send, create tx draft with this token
3. go back to summary, remove this token
4. go back to send (draft points to unsigned token - send form is broken)