### PR TITLE
Modal fade animation

### DIFF
--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -5,6 +5,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import styled from 'styled-components';
 import colors from 'config/colors';
+import { FADE_IN } from 'config/animations';
 
 import { UI } from 'trezor-connect';
 import * as MODAL from 'actions/constants/modal';
@@ -31,6 +32,7 @@ import Stellar from 'components/modals/external/Stellar';
 
 import type { Props } from './Container';
 
+// TODO: animation not working
 const Fade = (props: { children: React.Node}) => (
     <CSSTransition
         {...props}
@@ -53,6 +55,7 @@ const ModalContainer = styled.div`
     align-items: center;
     overflow: auto;
     padding: 20px;
+    animation: ${FADE_IN} 0.3s;
 `;
 
 const ModalWindow = styled.div`

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import * as React from 'react';
-import { CSSTransition } from 'react-transition-group';
 
 import styled from 'styled-components';
 import colors from 'config/colors';

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -32,16 +32,6 @@ import Stellar from 'components/modals/external/Stellar';
 
 import type { Props } from './Container';
 
-// TODO: animation not working
-const Fade = (props: { children: React.Node}) => (
-    <CSSTransition
-        {...props}
-        timeout={1000}
-        classNames="fade"
-    >{ props.children }
-    </CSSTransition>
-);
-
 const ModalContainer = styled.div`
     position: fixed;
     z-index: 10000;
@@ -195,13 +185,11 @@ const Modal = (props: Props) => {
     }
 
     return (
-        <Fade key="modal-fade">
-            <ModalContainer>
-                <ModalWindow>
-                    { component }
-                </ModalWindow>
-            </ModalContainer>
-        </Fade>
+        <ModalContainer>
+            <ModalWindow>
+                { component }
+            </ModalWindow>
+        </ModalContainer>
     );
 };
 

--- a/src/config/animations.js
+++ b/src/config/animations.js
@@ -57,3 +57,12 @@ export const PULSATE = keyframes`
         opacity: 1.0;
     }
 `;
+
+export const FADE_IN = keyframes`
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+`;


### PR DESCRIPTION
Fade animation using css animation property instead of CSSTransition. I couldn't make it to work with CSSTransition even with added missing css styles...

Fixes https://github.com/trezor/trezor-wallet/issues/231
![ezgif-4-1756ab1cb871](https://user-images.githubusercontent.com/6961901/49864454-ca2aea80-fe02-11e8-9427-cb6a05858150.gif)
