### PR TITLE
Console warnings cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "rc-tooltip": "^3.7.0",
         "react": "^16.6.3",
         "react-dom": "^16.6.3",
-        "react-hot-loader": "^4.3.4",
+        "react-hot-loader": "^4.6.2",
         "react-json-view": "^1.19.1",
         "react-qr-svg": "^2.1.0",
         "react-redux": "^5.0.7",

--- a/src/components/DeviceHeader/index.js
+++ b/src/components/DeviceHeader/index.js
@@ -101,6 +101,7 @@ const DeviceHeader = ({
     isAccessible = true,
     disabled = false,
     isSelected = false,
+    className,
 }) => {
     const status = getStatus(device);
     return (
@@ -109,6 +110,7 @@ const DeviceHeader = ({
             isOpen={isOpen}
             isHoverable={isHoverable}
             disabled={disabled}
+            className={className}
         >
             <ClickWrapper
                 disabled={disabled}
@@ -139,6 +141,7 @@ DeviceHeader.propTypes = {
     isOpen: PropTypes.bool,
     isSelected: PropTypes.bool,
     onClickWrapper: PropTypes.func.isRequired,
+    className: PropTypes.string,
 };
 
 export default DeviceHeader;

--- a/src/store.js
+++ b/src/store.js
@@ -47,9 +47,11 @@ if (buildUtils.isDev()) {
         collapsed: true,
     });
 
-    if (window && typeof window.devToolsExtension === 'function') {
-        enhancers.push(window.devToolsExtension());
+    /* eslint-disable no-underscore-dangle */
+    if (window && typeof window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ === 'function') {
+        enhancers.push(window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__());
     }
+    /* eslint-enable */
 
     composedEnhancers = compose(
         applyMiddleware(logger, ...middlewares, ...services),

--- a/src/views/Wallet/components/LeftNavigation/components/StickyContainer/index.js
+++ b/src/views/Wallet/components/LeftNavigation/components/StickyContainer/index.js
@@ -19,11 +19,10 @@ type State = {
     footerFixed: boolean,
 }
 
-const AsideWrapper = styled.aside.attrs({
-    style: ({ minHeight }) => ({
-        minHeight,
-    }),
-})`
+const AsideWrapper = styled.aside.attrs(props => ({
+    style: { minHeight: props.minHeight },
+}))`
+
     position: relative;
     top: 0px;
     width: 320px;
@@ -33,13 +32,13 @@ const AsideWrapper = styled.aside.attrs({
     border-right: 1px solid ${colors.DIVIDER};
 `;
 
-const StickyContainerWrapper = styled.div.attrs({
-    style: ({ top, left, paddingBottom }) => ({
-        top,
-        left,
-        paddingBottom,
-    }),
-})`
+const StickyContainerWrapper = styled.div.attrs(props => ({
+    style: {
+        top: props.top,
+        left: props.left,
+        paddingBottom: props.paddingBottom,
+    },
+}))`
     position: fixed;
     border-right: 1px solid ${colors.DIVIDER};
     width: 320px;

--- a/src/views/Wallet/components/LeftNavigation/index.js
+++ b/src/views/Wallet/components/LeftNavigation/index.js
@@ -45,11 +45,9 @@ const TransitionContentWrapper = styled.div`
     vertical-align: top;
 `;
 
-const Footer = styled.div.attrs({
-    style: ({ position }) => ({
-        position,
-    }),
-})`
+const Footer = styled.div.attrs(props => ({
+    style: { position: props.position },
+}))`
     width: 320px;
     bottom: 0;
     background: ${colors.MAIN};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7443,6 +7443,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -9729,17 +9734,20 @@ react-dom@^16.6.3:
     prop-types "^15.6.2"
     scheduler "^0.11.2"
 
-react-hot-loader@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.3.4.tgz#4f9bdd55bb20d77a6ae8931fa1c187e5f0ce6279"
-  integrity sha512-LlKjtHq+RhDq9xm6crXojbkzrEvli5F4/RaeJ//XtDWrwwsAHDjEqKfZZiPCxv7gWV2cxE3YE8TXeE9BDzLqOA==
+react-hot-loader@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.6.2.tgz#9844b76a7bf4b6fdd45dd91f7e757ddf3aad5289"
+  integrity sha512-9XxH/t9jblu4vUDgxHcMLwvm4aOhaoxazzTP9vwjTVzOgU987T4rDYA85XrlmbDan9WkD+h/iVHOK8F8UnQsDg==
   dependencies:
     fast-levenshtein "^2.0.6"
     global "^4.3.0"
     hoist-non-react-statics "^2.5.0"
+    loader-utils "^1.1.0"
+    lodash.merge "^4.6.1"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
+    source-map "^0.7.3"
 
 react-input-autosize@^2.2.1:
   version "2.2.1"
@@ -11066,7 +11074,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.2:
+source-map@^0.7.2, source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==


### PR DESCRIPTION
- switch to new attrs syntax, old one we currently use is deprecated
- bump version of react-hot-loader
- window.devToolsExtension was renamed to window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__.
- pass className prop to DeviceHeader component to get rid of styled components warning