### PR TITLE
Fix device status overflow

### DIFF
--- a/src/components/DeviceHeader/index.js
+++ b/src/components/DeviceHeader/index.js
@@ -48,8 +48,9 @@ const ClickWrapper = styled.div`
 `;
 
 const LabelWrapper = styled.div`
-    flex: 1;
+    flex: 1 1 auto;
     padding-left: 18px;
+    overflow: hidden;
 `;
 
 const Name = styled.div`
@@ -73,6 +74,8 @@ const Status = styled.div`
 const IconWrapper = styled.div`
     padding-right: 25px;
     display: flex;
+    flex: 1 0 0;
+    justify-content: flex-end;
 `;
 
 const ImageWrapper = styled.div`
@@ -122,7 +125,7 @@ const DeviceHeader = ({
                 </ImageWrapper>
                 <LabelWrapper>
                     <Name>{device.instanceLabel}</Name>
-                    <Status>{getStatusName(status)}</Status>
+                    <Status title={getStatusName(status)}>{getStatusName(status)}</Status>
                 </LabelWrapper>
                 <IconWrapper>
                     {icon && !disabled && isAccessible && icon}


### PR DESCRIPTION
Fix https://github.com/trezor/trezor-wallet/issues/310
- used flexbox magic to prevent icon's wrapper from shrinking and to allow device status to fill rest of the container
- shows expanded status on hover

<img width="400" alt="screenshot 2019-01-08 at 15 22 46" src="https://user-images.githubusercontent.com/6961901/50836366-59231800-1359-11e9-93a0-db0fb4595f1b.png">
