### PR TITLE
Fix fee label overflow

### DIFF
--- a/src/views/Wallet/views/Account/Send/ethereum/index.js
+++ b/src/views/Wallet/views/Account/Send/ethereum/index.js
@@ -87,6 +87,19 @@ const FeeOptionWrapper = styled.div`
     justify-content: space-between;
 `;
 
+const OptionValue = styled(P)`
+    flex: 0 0 0;
+    margin-right: 5px;
+`;
+
+const OptionLabel = styled(P)`
+    flex: 0 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: right;
+    word-break: break-all;
+`;
+
 const FeeLabelWrapper = styled.div`
     display: flex;
     align-items: center;
@@ -348,8 +361,8 @@ const AccountSend = (props: Props) => {
                     options={feeLevels}
                     formatOptionLabel={option => (
                         <FeeOptionWrapper>
-                            <P>{option.value}</P>
-                            <P>{option.label}</P>
+                            <OptionValue>{option.value}</OptionValue>
+                            <OptionLabel>{option.label}</OptionLabel>
                         </FeeOptionWrapper>
                     )}
                 />

--- a/src/views/Wallet/views/Account/Send/ethereum/index.js
+++ b/src/views/Wallet/views/Account/Send/ethereum/index.js
@@ -88,7 +88,8 @@ const FeeOptionWrapper = styled.div`
 `;
 
 const OptionValue = styled(P)`
-    flex: 0 0 0;
+    flex: 1 0 auto;
+    min-width: 70px;
     margin-right: 5px;
 `;
 

--- a/src/views/Wallet/views/Account/Send/ripple/index.js
+++ b/src/views/Wallet/views/Account/Send/ripple/index.js
@@ -75,7 +75,8 @@ const FeeOptionWrapper = styled.div`
 `;
 
 const OptionValue = styled(P)`
-    flex: 0 0 0;
+    flex: 1 0 auto;
+    min-width: 70px;
     margin-right: 5px;
 `;
 

--- a/src/views/Wallet/views/Account/Send/ripple/index.js
+++ b/src/views/Wallet/views/Account/Send/ripple/index.js
@@ -74,6 +74,19 @@ const FeeOptionWrapper = styled.div`
     justify-content: space-between;
 `;
 
+const OptionValue = styled(P)`
+    flex: 0 0 0;
+    margin-right: 5px;
+`;
+
+const OptionLabel = styled(P)`
+    flex: 0 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: right;
+    word-break: break-all;
+`;
+
 const FeeLabelWrapper = styled.div`
     display: flex;
     align-items: center;
@@ -302,8 +315,8 @@ const AccountSend = (props: Props) => {
                     options={feeLevels}
                     formatOptionLabel={option => (
                         <FeeOptionWrapper>
-                            <P>{option.value}</P>
-                            <P>{option.label}</P>
+                            <OptionValue>{option.value}</OptionValue>
+                            <OptionLabel>{option.label}</OptionLabel>
                         </FeeOptionWrapper>
                     )}
                 />


### PR DESCRIPTION
Fix https://github.com/trezor/trezor-wallet/issues/314
- truncate fee label (you can still see the full number in select)

<img width="384" alt="screenshot 2019-01-09 at 13 55 16" src="https://user-images.githubusercontent.com/6961901/50900708-520e0f80-1416-11e9-8750-58f995cd7588.png">

