### PR TITLE
Fix/signtx modal design

### DIFF
--- a/src/components/modals/confirm/SignTx/index.js
+++ b/src/components/modals/confirm/SignTx/index.js
@@ -45,7 +45,6 @@ const StyledP = styled(P)`
 
 const Address = styled(StyledP)`
     word-wrap: break-word;
-    padding-bottom: 26px;
     line-height: ${LINE_HEIGHT.SMALL};
 `;
 

--- a/src/components/modals/confirm/SignTx/index.js
+++ b/src/components/modals/confirm/SignTx/index.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import icons from 'config/icons';
 import colors from 'config/colors';
-import { LINE_HEIGHT, FONT_SIZE } from 'config/variables';
+import { LINE_HEIGHT, FONT_SIZE, FONT_WEIGHT } from 'config/variables';
 
 import P from 'components/Paragraph';
 import Icon from 'components/Icon';
@@ -21,7 +21,6 @@ type Props = {
 
 const Wrapper = styled.div`
     width: 390px;
-    padding: 12px 10px;
 `;
 
 const Header = styled.div`
@@ -32,16 +31,27 @@ const Content = styled.div`
     border-top: 1px solid ${colors.DIVIDER};
     background: ${colors.MAIN};
     padding: 24px 48px;
+    border-radius: 4px;
 `;
 
 const StyledP = styled(P)`
+    padding-bottom: 20px;
+    color: ${colors.TEXT};
+    font-size: ${FONT_SIZE.BASE};
+    &:last-child {
+        padding-bottom: 0px;
+    }
+`;
+
+const Address = styled(StyledP)`
     word-wrap: break-word;
-    padding: 5px 0;
+    padding-bottom: 26px;
     line-height: ${LINE_HEIGHT.SMALL};
 `;
 
 const Label = styled.div`
-    padding-top: 5px;
+    padding-bottom: 6px;
+    font-weight: ${FONT_WEIGHT.MEDIUM};
     font-size: ${FONT_SIZE.SMALL};
     color: ${colors.TEXT_SECONDARY};
 `;
@@ -64,11 +74,11 @@ const ConfirmSignTx = (props: Props) => {
             </Header>
             <Content>
                 <Label>Send</Label>
-                <P>{`${amount} ${currency}` }</P>
+                <StyledP>{`${amount} ${currency}` }</StyledP>
                 <Label>To</Label>
-                <StyledP>{ address }</StyledP>
+                <Address>{ address }</Address>
                 <Label>Fee</Label>
-                <P>{ selectedFeeLevel.label }</P>
+                <StyledP>{ selectedFeeLevel.label }</StyledP>
             </Content>
         </Wrapper>
     );

--- a/src/components/modals/confirm/SignTx/index.js
+++ b/src/components/modals/confirm/SignTx/index.js
@@ -56,6 +56,10 @@ const Label = styled.div`
     color: ${colors.TEXT_SECONDARY};
 `;
 
+const FeeLevelName = styled(StyledP)`
+    padding-bottom: 0px;
+`;
+
 const ConfirmSignTx = (props: Props) => {
     const {
         amount,
@@ -78,6 +82,7 @@ const ConfirmSignTx = (props: Props) => {
                 <Label>To</Label>
                 <Address>{ address }</Address>
                 <Label>Fee</Label>
+                <FeeLevelName>{selectedFeeLevel.value}</FeeLevelName>
                 <StyledP>{ selectedFeeLevel.label }</StyledP>
             </Content>
         </Wrapper>


### PR DESCRIPTION
- fix https://github.com/trezor/trezor-wallet/issues/316
- nicer look
- added fee level label
<img width="454" alt="screenshot 2019-01-09 at 17 52 47" src="https://user-images.githubusercontent.com/6961901/50915185-872b5980-1438-11e9-91f7-e571bcd31e57.png">

Before:
<img width="516" alt="screenshot 2019-01-05 at 20 15 11" src="https://user-images.githubusercontent.com/6961901/50902733-fba3cf80-141b-11e9-8726-ec5286d4a1b6.png">

