### PR TITLE
Generate lighter/easier to read color for token icons

### DIFF
--- a/src/views/Wallet/views/Account/Summary/components/Token/index.js
+++ b/src/views/Wallet/views/Account/Summary/components/Token/index.js
@@ -58,8 +58,8 @@ class AddedToken extends PureComponent {
     }
 
     render() {
-        const bgColor = new ColorHash({ lightness: 0.16 });
-        const textColor = new ColorHash();
+        const bgColor = new ColorHash({ lightness: 0.9 });
+        const textColor = new ColorHash({ lightness: 0.3, saturation: 1 });
 
         return (
             <TokenWrapper key={this.props.token.symbol}>


### PR DESCRIPTION
<img width="237" alt="screenshot 2019-01-10 at 17 25 47" src="https://user-images.githubusercontent.com/6961901/50982347-43e6ee80-14fd-11e9-906c-16a7d03ebed0.png">

Before:
<img width="269" alt="screenshot 2019-01-10 at 17 14 36" src="https://user-images.githubusercontent.com/6961901/50982346-43e6ee80-14fd-11e9-8456-d4d2e040614a.png">