### PR TITLE
[WIP] Revamped notifications design

### DIFF
--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { getPrimaryColor, getSecondaryColor, getIcon } from 'utils/notification';
 import Icon from 'components/Icon';
 import icons from 'config/icons';
+import colors from 'config/colors';
 import { FONT_WEIGHT, FONT_SIZE } from 'config/variables';
 
 import * as NotificationActions from 'actions/NotificationActions';
@@ -24,59 +25,73 @@ type Props = {
     loading?: boolean
 };
 
-const Wrapper = styled.div`
-    width: 100%;
-    position: relative;
+const StyledNotification = styled.div`
     display: flex;
-    justify-content: center;
-    color: ${props => getPrimaryColor(props.type)};
-    background: ${props => getSecondaryColor(props.type)};
+    width: 100%;
+    background: ${colors.WHITE};
+    margin: 10px 0px;
+    box-shadow: 0px 0px 6px 1px rgba(0,0,0,0.2);
+    border-left: 4px solid ${props => getPrimaryColor(props.type)};
+    border-radius: 4px;
+    padding: 6px 12px;
+
+    & + & {
+        margin-top: 0px;
+    }
 `;
 
-const Content = styled.div`
+const Column = styled.div`
+    display: flex;
     width: 100%;
-    max-width: 1170px;
-    padding: 24px;
+    flex-direction: column;
+    justify-content: center;
+`;
+
+const Body = styled.div`
+    width: 100%;
     display: flex;
     flex-direction: row;
     text-align: left;
     align-items: center;
+    padding: 6px 0px;
+    background: ${props => getSecondaryColor(props.type)};
 `;
 
-const Body = styled.div`
+const Header = styled.div`
     display: flex;
+    width: 100%;
+    align-items: center;
+    padding: 6px 0px;
+    border-top-left-radius: 4px; 
+    border-top-right-radius: 4px; 
+    color: ${props => getPrimaryColor(props.type)};
 `;
 
 const Message = styled.div`
     font-size: ${FONT_SIZE.SMALL};
+    color: ${colors.TEXT_SECONDARY};
+    padding-right: 5px;
 `;
 
 const Title = styled.div`
-    padding-bottom: 5px;
-    padding-top: 1px;
     font-weight: ${FONT_WEIGHT.MEDIUM};
 `;
 
 const CloseClick = styled.div`
-    margin-left: 24px;
-    align-self: flex-start;
+    margin-left: auto;
     cursor: pointer;
 `;
 
 const StyledIcon = styled(Icon)`
-    position: relative;
-    top: -7px;
     min-width: 20px;
 `;
 
 const IconWrapper = styled.div`
     min-width: 30px;
-`;
-
-const Texts = styled.div`
+    padding-right: 12px;
     display: flex;
-    padding: 0 10px 0 0;
-    flex-direction: column;
+    align-items: center;
+    flex: 1 0 auto;
 `;
 
 const AdditionalContent = styled.div`
@@ -96,47 +111,51 @@ const Notification = (props: Props): React$Element<string> => {
     const close: Function = typeof props.close === 'function' ? props.close : () => {}; // TODO: add default close action
 
     return (
-        <Wrapper className={props.className} type={props.type}>
-            <Content>
-                {props.loading && <Loader size={50} /> }
-                <Body>
-                    <IconWrapper>
-                        <StyledIcon
-                            color={getPrimaryColor(props.type)}
-                            icon={getIcon(props.type)}
-                        />
-                    </IconWrapper>
-                    <Texts>
-                        <Title>{ props.title }</Title>
-                        { props.message ? <Message>{props.message}</Message> : '' }
-                    </Texts>
-                </Body>
-                <AdditionalContent>
-                    {props.actions && props.actions.length > 0 && (
-                        <ActionContent>
-                            {props.actions.map(action => (
-                                <NotificationButton
-                                    key={action.label}
-                                    type={props.type}
-                                    isLoading={props.isActionInProgress}
-                                    onClick={() => { close(); action.callback(); }}
-                                >{action.label}
-                                </NotificationButton>
-                            ))}
-                        </ActionContent>
+        <StyledNotification className={props.className} type={props.type}>
+            <IconWrapper>
+                <StyledIcon
+                    color={getPrimaryColor(props.type)}
+                    icon={getIcon(props.type)}
+                    size={48}
+                />
+            </IconWrapper>
+            <Column>
+                <Header type={props.type}>
+                    {props.loading && <Loader size={24} /> }
+                    <Title>{ props.title }</Title>
+                    {props.cancelable && (
+                        <CloseClick onClick={() => close()}>
+                            <Icon
+                                color={colors.TEXT_SECONDARY}
+                                hoverColor={colors.TEXT_PRIMARY}
+                                icon={icons.CLOSE}
+                                size={20}
+                            />
+                        </CloseClick>
                     )}
-                </AdditionalContent>
-                {props.cancelable && (
-                    <CloseClick onClick={() => close()}>
-                        <Icon
-                            color={getPrimaryColor(props.type)}
-                            icon={icons.CLOSE}
-                            size={20}
-                        />
-                    </CloseClick>
-                )}
-            </Content>
-        </Wrapper>
+                </Header>
+                { (props.message || (props.actions || []).length > 0) ? (
+                    <Body>
+                        { props.message ? <Message>{props.message}</Message> : '' }
+                        <AdditionalContent>
+                            {props.actions && props.actions.length > 0 && (
+                                <ActionContent>
+                                    {props.actions.map(action => (
+                                        <NotificationButton
+                                            key={action.label}
+                                            type={props.type}
+                                            isLoading={props.isActionInProgress}
+                                            onClick={() => { close(); action.callback(); }}
+                                        >{action.label}
+                                        </NotificationButton>
+                                    ))}
+                                </ActionContent>
+                            )}
+                        </AdditionalContent>
+                    </Body>
+                ) : null }
+            </Column>
+        </StyledNotification>
     );
 };
 

--- a/src/components/notifications/App/Container.js
+++ b/src/components/notifications/App/Container.js
@@ -1,0 +1,39 @@
+/* @flow */
+import * as React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import type { MapStateToProps, MapDispatchToProps } from 'react-redux';
+import type { State, Dispatch } from 'flowtype';
+
+import * as NotificationActions from 'actions/NotificationActions';
+import * as RouterActions from 'actions/RouterActions';
+
+import AppNotifications from './index';
+
+export type StateProps = {
+    connect: $ElementType<State, 'connect'>;
+    wallet: $ElementType<State, 'wallet'>;
+    children?: React.Node;
+}
+
+export type DispatchProps = {
+    close: typeof NotificationActions.close;
+    routerActions: typeof RouterActions;
+}
+
+export type Props = StateProps & DispatchProps;
+
+type OwnProps = {};
+
+const mapStateToProps: MapStateToProps<State, OwnProps, StateProps> = (state: State): StateProps => ({
+    connect: state.connect,
+    wallet: state.wallet,
+});
+
+const mapDispatchToProps: MapDispatchToProps<Dispatch, OwnProps, DispatchProps> = (dispatch: Dispatch): DispatchProps => ({
+    close: bindActionCreators(NotificationActions.close, dispatch),
+    routerActions: bindActionCreators(RouterActions, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(AppNotifications);

--- a/src/components/notifications/App/components/OnlineStatus/index.js
+++ b/src/components/notifications/App/components/OnlineStatus/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Notification from 'components/Notification';
 
-import type { Props } from '../../index';
+import type { Props } from '../../Container';
 
 export default (props: Props) => {
     const { online } = props.wallet;

--- a/src/components/notifications/App/components/UpdateBridge/index.js
+++ b/src/components/notifications/App/components/UpdateBridge/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Notification from 'components/Notification';
 
-import type { Props } from '../../index';
+import type { Props } from '../../Container';
 
 export default (props: Props) => {
     if (props.connect.transport && props.connect.transport.outdated) {

--- a/src/components/notifications/App/components/UpdateFirmware/index.js
+++ b/src/components/notifications/App/components/UpdateFirmware/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Notification from 'components/Notification';
 
-import type { Props } from '../../index';
+import type { Props } from '../../Container';
 
 export default (props: Props) => {
     const { selectedDevice } = props.wallet;
@@ -12,7 +12,8 @@ export default (props: Props) => {
         <Notification
             key="update-firmware"
             type="warning"
-            title="Firmware update"
+            title="A new Trezor firmware update is available."
+            message="Upgrade to access the newest features"
             actions={
                 [{
                     label: 'Update',

--- a/src/components/notifications/App/index.js
+++ b/src/components/notifications/App/index.js
@@ -1,49 +1,36 @@
 /* @flow */
 import * as React from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import styled from 'styled-components';
 
-import type { MapStateToProps, MapDispatchToProps } from 'react-redux';
-import type { State, Dispatch } from 'flowtype';
-
-import * as NotificationActions from 'actions/NotificationActions';
-import * as RouterActions from 'actions/RouterActions';
+import { SCREEN_SIZE } from 'config/variables';
 
 import OnlineStatus from './components/OnlineStatus';
 import UpdateBridge from './components/UpdateBridge';
 import UpdateFirmware from './components/UpdateFirmware';
 
-export type StateProps = {
-    connect: $ElementType<State, 'connect'>;
-    wallet: $ElementType<State, 'wallet'>;
-    children?: React.Node;
-}
+import type { Props } from './Container';
 
-export type DispatchProps = {
-    close: typeof NotificationActions.close;
-    routerActions: typeof RouterActions;
-}
+const Wrapper = styled.div`
+    position: relative;
+    display: flex;
+    justify-content: center;
+    max-width: 1170px;
+    width: 100%;
+    margin: 0 auto;
+    flex-direction: column;
 
-export type Props = StateProps & DispatchProps;
+    @media screen and (max-width: ${SCREEN_SIZE.LG}) {
+        padding-left: 5px;
+        padding-right: 5px;
+    }
+`;
 
-type OwnProps = {};
-
-const Notifications = (props: Props) => (
-    <React.Fragment>
+const AppNotifications = (props: Props) => (
+    <Wrapper>
         <OnlineStatus {...props} />
         <UpdateBridge {...props} />
         <UpdateFirmware {...props} />
-    </React.Fragment>
+    </Wrapper>
 );
 
-const mapStateToProps: MapStateToProps<State, OwnProps, StateProps> = (state: State): StateProps => ({
-    connect: state.connect,
-    wallet: state.wallet,
-});
-
-const mapDispatchToProps: MapDispatchToProps<Dispatch, OwnProps, DispatchProps> = (dispatch: Dispatch): DispatchProps => ({
-    close: bindActionCreators(NotificationActions.close, dispatch),
-    routerActions: bindActionCreators(RouterActions, dispatch),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Notifications);
+export default AppNotifications;

--- a/src/components/notifications/Context/Container.js
+++ b/src/components/notifications/Context/Container.js
@@ -1,0 +1,45 @@
+/* @flow */
+import * as React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import type { MapStateToProps, MapDispatchToProps } from 'react-redux';
+import type { State, Dispatch } from 'flowtype';
+
+import { reconnect } from 'actions/DiscoveryActions';
+import * as NotificationActions from 'actions/NotificationActions';
+
+import ContextNotifications from './index';
+
+export type StateProps = {
+    router: $ElementType<State, 'router'>;
+    notifications: $ElementType<State, 'notifications'>;
+    selectedAccount: $ElementType<State, 'selectedAccount'>;
+    wallet: $ElementType<State, 'wallet'>;
+    blockchain: $ElementType<State, 'blockchain'>;
+    children?: React.Node;
+}
+
+export type DispatchProps = {
+    close: typeof NotificationActions.close;
+    blockchainReconnect: typeof reconnect;
+}
+
+export type Props = StateProps & DispatchProps;
+
+type OwnProps = {};
+
+const mapStateToProps: MapStateToProps<State, OwnProps, StateProps> = (state: State): StateProps => ({
+    router: state.router,
+    notifications: state.notifications,
+    selectedAccount: state.selectedAccount,
+    wallet: state.wallet,
+    blockchain: state.blockchain,
+});
+
+const mapDispatchToProps: MapDispatchToProps<Dispatch, OwnProps, DispatchProps> = (dispatch: Dispatch): DispatchProps => ({
+    close: bindActionCreators(NotificationActions.close, dispatch),
+    blockchainReconnect: bindActionCreators(reconnect, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ContextNotifications);

--- a/src/components/notifications/Context/components/Account/index.js
+++ b/src/components/notifications/Context/components/Account/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Notification from 'components/Notification';
 
-import type { Props } from '../../index';
+import type { Props } from '../../Container';
 
 // There could be only one account notification
 export default (props: Props) => {

--- a/src/components/notifications/Context/components/Action/components/NotificationsGroups/components/Group/index.js
+++ b/src/components/notifications/Context/components/Action/components/NotificationsGroups/components/Group/index.js
@@ -15,7 +15,7 @@ const Header = styled.div`
     justify-content: space-between;
     background: ${colors.WHITE};
     align-items: center;
-    padding: 5px 10px;
+    padding: 5px 0px;
     border-bottom: 1px solid ${colors.BACKGROUND};
 `;
 
@@ -32,13 +32,7 @@ const Title = styled.div`
     color: ${props => props.color};
 `;
 
-const StyledNotification = styled(Notification)`
-    border-bottom: 1px solid ${colors.WHITE};
-
-    &:last-child {
-        border: 0;
-    }
-`;
+const StyledNotification = styled(Notification)``;
 
 class Group extends PureComponent {
     constructor() {

--- a/src/components/notifications/Context/components/Action/components/NotificationsGroups/index.js
+++ b/src/components/notifications/Context/components/Action/components/NotificationsGroups/index.js
@@ -76,7 +76,7 @@ class NotificationsGroup extends PureComponent {
         const notificationGroups = this.groupNotifications(notifications);
         const sortedNotifications = this.sortByPriority(notificationGroups);
 
-        return (
+        return notifications.length > 0 ? (
             <Wrapper>
                 {Object.keys(sortedNotifications).map(group => (
                     <Group
@@ -87,7 +87,7 @@ class NotificationsGroup extends PureComponent {
                     />
                 ))}
             </Wrapper>
-        );
+        ) : null;
     }
 }
 

--- a/src/components/notifications/Context/components/Action/index.js
+++ b/src/components/notifications/Context/components/Action/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import NotificationsGroups from './components/NotificationsGroups';
 
-import type { Props } from '../../index';
+import type { Props } from '../../Container';
 
 export default (props: Props) => {
     const { notifications, close } = props;

--- a/src/components/notifications/Context/components/Static/index.js
+++ b/src/components/notifications/Context/components/Static/index.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import Notification from 'components/Notification';
 import Bignumber from 'bignumber.js';
 
-import type { Props } from '../../index';
+import type { Props } from '../../Container';
 
 export default (props: Props) => {
     const { selectedAccount } = props;

--- a/src/components/notifications/Context/index.js
+++ b/src/components/notifications/Context/index.js
@@ -1,55 +1,28 @@
 /* @flow */
 import * as React from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-
-import type { MapStateToProps, MapDispatchToProps } from 'react-redux';
-import type { State, Dispatch } from 'flowtype';
-
-import { reconnect } from 'actions/DiscoveryActions';
-import * as NotificationActions from 'actions/NotificationActions';
+import styled from 'styled-components';
 
 import StaticNotifications from './components/Static';
 import AccountNotifications from './components/Account';
 import ActionNotifications from './components/Action';
 
-export type StateProps = {
-    router: $ElementType<State, 'router'>;
-    notifications: $ElementType<State, 'notifications'>;
-    selectedAccount: $ElementType<State, 'selectedAccount'>;
-    wallet: $ElementType<State, 'wallet'>;
-    blockchain: $ElementType<State, 'blockchain'>;
-    children?: React.Node;
-}
+import type { Props } from './Container';
 
-export type DispatchProps = {
-    close: typeof NotificationActions.close;
-    blockchainReconnect: typeof reconnect;
-}
+const Wrapper = styled.div`
+    width: 100%;
+    padding: 10px 25px 5px 25px;
 
-export type Props = StateProps & DispatchProps;
+    &:empty {
+        padding: 0px; /* don't render padding when there is no child/notification in the wrapper */
+    }
+`;
 
-type OwnProps = {};
-
-const Notifications = (props: Props) => (
-    <React.Fragment>
+const ContextNotifications = (props: Props) => (
+    <Wrapper>
         <StaticNotifications {...props} />
         <AccountNotifications {...props} />
         <ActionNotifications {...props} />
-    </React.Fragment>
+    </Wrapper>
 );
 
-const mapStateToProps: MapStateToProps<State, OwnProps, StateProps> = (state: State): StateProps => ({
-    router: state.router,
-    notifications: state.notifications,
-    selectedAccount: state.selectedAccount,
-    wallet: state.wallet,
-    blockchain: state.blockchain,
-});
-
-const mapDispatchToProps: MapDispatchToProps<Dispatch, OwnProps, DispatchProps> = (dispatch: Dispatch): DispatchProps => ({
-    close: bindActionCreators(NotificationActions.close, dispatch),
-    blockchainReconnect: bindActionCreators(reconnect, dispatch),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Notifications);
+export default ContextNotifications;

--- a/src/views/Landing/components/LandingWrapper/index.js
+++ b/src/views/Landing/components/LandingWrapper/index.js
@@ -6,7 +6,7 @@ import Header from 'components/Header';
 import Footer from 'components/Footer';
 import Log from 'components/Log';
 import Loader from 'components/Loader';
-import ContextNotifications from 'components/notifications/Context';
+import ContextNotifications from 'components/notifications/Context/Container';
 import colors from 'config/colors';
 
 import InitializationError from '../InitializationError';

--- a/src/views/Wallet/index.js
+++ b/src/views/Wallet/index.js
@@ -16,8 +16,8 @@ import { bindActionCreators } from 'redux';
 import Header from 'components/Header';
 import Footer from 'components/Footer';
 import ModalContainer from 'components/modals/Container';
-import AppNotifications from 'components/notifications/App';
-import ContextNotifications from 'components/notifications/Context';
+import AppNotifications from 'components/notifications/App/Container';
+import ContextNotifications from 'components/notifications/Context/Container';
 
 import { SCREEN_SIZE } from 'config/variables';
 

--- a/src/views/Wallet/views/Acquire/index.js
+++ b/src/views/Wallet/views/Acquire/index.js
@@ -19,6 +19,7 @@ const Wrapper = styled.div`
     background: ${colors.WHITE};
     flex-direction: column;
     flex: 1;
+    padding: 10px 25px 5px 25px;
 `;
 
 const Acquire = (props: Props) => (

--- a/src/views/Wallet/views/UnreadableDevice/index.js
+++ b/src/views/Wallet/views/UnreadableDevice/index.js
@@ -4,7 +4,9 @@ import React from 'react';
 import styled from 'styled-components';
 import Notification from 'components/Notification';
 
-const Wrapper = styled.div``;
+const Wrapper = styled.div`
+    padding: 10px 25px 5px 25px;
+`;
 
 const UnreadableDevice = () => (
     <Wrapper>


### PR DESCRIPTION
- new look with much better color contrast (here is the old warning notification for reference https://contrastchecker.com/?c=EB8A00&b=FFEFD9)
- separated container and presentational component for app and context notifications

TODO
- drop box-shadow
- fix layout when there is title, action buttons  and no description message

![webp net-gifmaker 3](https://user-images.githubusercontent.com/6961901/52083197-17277380-259f-11e9-8d93-2d4efdee4732.gif)

without box-shadow:
<img width="1296" alt="screenshot 2019-02-06 at 17 23 07" src="https://user-images.githubusercontent.com/6961901/52356222-22adeb00-2a34-11e9-8997-d379a68e44fc.png">
