### PR TITLE
Add webpack plugin for hot reloader

### DIFF
--- a/webpack/dev.babel.js
+++ b/webpack/dev.babel.js
@@ -45,6 +45,7 @@ module.exports = {
                 exclude: /node_modules/,
                 use: [
                     'babel-loader',
+                    'react-hot-loader/webpack',
                     {
                         loader: 'eslint-loader',
                         options: {


### PR DESCRIPTION
>  Latest (4.5.0+, beta) version of React-Hot-Loader could be quite 🔥!
> 
>     RHL will patch React, replace React-DOM by React-🔥-DOM and work with fiber directly
> 
>     (required) use webpack plugin to let RHL patch React-DOM for you.

https://github.com/gaearon/react-hot-loader#webpack-plugin