### PR TITLE
Downgrade connected-react-router@6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "bignumber.js": "8.0.2",
         "color-hash": "^1.0.3",
         "commander": "^2.19.0",
-        "connected-react-router": "^6.2.2",
+        "connected-react-router": "6.0.0",
         "copy-webpack-plugin": "^4.6.0",
         "cross-env": "^5.2.0",
         "date-fns": "^1.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,10 +2949,10 @@ connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
-connected-react-router@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-6.2.2.tgz#10ed0942ee2032de7cb0fd8479bde526853906ed"
-  integrity sha512-tPI3s7yYtnTt/XLoQFsQqIEQxdQCrsZltEdozjG7LPkOTNglJJ7WqUqnlnh9thC6ebavfaJoTtPa9G2EibuJbg==
+connected-react-router@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-6.0.0.tgz#cb7ccbbc5ed353832ecd91d68289c916e8aba734"
+  integrity sha512-TarPqf2wY3cz993Mw3eBg2U12M5OmaGwKzJsinvRQh61nKb8WMUvimyhu6u2HeWS8625PHFXjNOU0OIAMWj/bQ==
   dependencies:
     immutable "^3.8.1"
     seamless-immutable "^7.1.3"


### PR DESCRIPTION
Downgrade connected-react-router@6.0.0 to fix https://github.com/trezor/trezor-wallet/issues/373
- [most likely related issue](https://github.com/supasate/connected-react-router/issues/260) in connected-react-router repo