### PR TITLE
Fix/coins menu padding

### DIFF
--- a/src/components/images/CoinLogo/index.js
+++ b/src/components/images/CoinLogo/index.js
@@ -5,35 +5,22 @@ import PropTypes from 'prop-types';
 const Wrapper = styled.div`
     padding-right: 20px;
     width: 40px;
+    display: flex;
+    justify-content: center;
 `;
 
 const Logo = styled.img`
-    width: ${props => (props.hasLongIcon ? '15px' : '23px')};
-    margin-left: ${props => (props.hasLongIcon ? '3px' : '0px')};
+    height: 23px;
     display: block;
 `;
 
 class CoinLogo extends PureComponent {
-    constructor() {
-        super();
-        this.longIcons = ['etc', 'eth', 'trop'];
-    }
-
-    hasLongIcon(network) {
-        let hasLongIcon = false;
-        if (this.longIcons.includes(network)) {
-            hasLongIcon = true;
-        }
-        return hasLongIcon;
-    }
-
     render() {
         const { network, className, standalone } = this.props;
 
         const logo = (
             <Logo
                 className={className}
-                hasLongIcon={this.hasLongIcon(network)}
                 src={require(`images/coins/${network}.png`)} // eslint-disable-line
             />
         );

--- a/src/config/variables.js
+++ b/src/config/variables.js
@@ -63,7 +63,7 @@ export const BORDER_WIDTH = {
 };
 
 export const LEFT_NAVIGATION_ROW = {
-    PADDING: '16px 24px',
+    PADDING: '0px 24px',
 };
 
 const TRANSITION_TIME = {

--- a/src/config/variables.js
+++ b/src/config/variables.js
@@ -63,7 +63,7 @@ export const BORDER_WIDTH = {
 };
 
 export const LEFT_NAVIGATION_ROW = {
-    PADDING: '0px 24px',
+    PADDING: '16px 24px',
 };
 
 const TRANSITION_TIME = {

--- a/src/views/Wallet/components/LeftNavigation/components/RowCoin/index.js
+++ b/src/views/Wallet/components/LeftNavigation/components/RowCoin/index.js
@@ -15,6 +15,8 @@ const CoinNameWrapper = styled.div`
 
 const RowCoinWrapper = styled.div`
     padding: ${LEFT_NAVIGATION_ROW.PADDING};
+    padding-top: 0;
+    padding-bottom: 0;
     height: 44px;
     display: block;
     font-size: ${FONT_SIZE.BIG};

--- a/src/views/Wallet/components/LeftNavigation/components/RowCoin/index.js
+++ b/src/views/Wallet/components/LeftNavigation/components/RowCoin/index.js
@@ -15,7 +15,7 @@ const CoinNameWrapper = styled.div`
 
 const RowCoinWrapper = styled.div`
     padding: ${LEFT_NAVIGATION_ROW.PADDING};
-    height: 50px;
+    height: 44px;
     display: block;
     font-size: ${FONT_SIZE.BIG};
     color: ${colors.TEXT_PRIMARY};


### PR DESCRIPTION
- set same height to coin logos (23px), centered with flexbox (no need for the has-long-icon logic now), fixes future problems with icons with weird width/height ration (like a tezos logo)
- smaller height of coin menu item (44px, same as in mytrezor), imho looks better
<img width="338" alt="Screenshot 2019-03-16 at 17 02 55" src="https://user-images.githubusercontent.com/6961901/54477989-ac0fc480-480d-11e9-988c-4468c9f0fe39.png">
