### PR TITLE
Fix/renderwebusb button in device menu when connect trasport type is webusb

### DIFF
--- a/src/views/Wallet/components/LeftNavigation/components/DeviceMenu/index.js
+++ b/src/views/Wallet/components/LeftNavigation/components/DeviceMenu/index.js
@@ -58,8 +58,7 @@ class DeviceMenu extends PureComponent<Props> {
         window.addEventListener('mousedown', this.mouseDownHandler, false);
         // window.addEventListener('blur', this.blurHandler, false);
         const { transport } = this.props.connect;
-        if (transport.type && transport.version.indexOf('webusb') >= 0)
-            TrezorConnect.renderWebUSBButton();
+        if (deviceUtils.isWebUSB(transport)) TrezorConnect.renderWebUSBButton();
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
Check for devices button in device menu didn't work because the condition for calling `TrezorConnect.renderWebUSBButton()`always returned false. It searched for 'webusb' substring in the `connect.transport.version` instead of `type`

<img width="217" alt="Screenshot 2019-03-26 at 15 12 41" src="https://user-images.githubusercontent.com/6961901/55004260-30b2cd80-4fda-11e9-82b0-2a302a664599.png">
