### PR TITLE
fix: setInitialUrl - race condition

### DIFF
--- a/src/actions/RouterActions.js
+++ b/src/actions/RouterActions.js
@@ -434,7 +434,6 @@ export const setInitialUrl = (): PayloadAction<boolean> => (
 
     // DEVICE.CONNECT race condition, "selectDevice" method was called but currently selectedDevice is in getState (auth) process
     // if so, consume this action (return true) to break "selectDevice" process
-    // "setInitialUrl" will be called again after AUTH_DEVICE action
     const { selectedDevice } = getState().wallet;
     if (
         selectedDevice &&

--- a/src/actions/RouterActions.js
+++ b/src/actions/RouterActions.js
@@ -429,19 +429,13 @@ export const setInitialUrl = (): PayloadAction<boolean> => (
     dispatch: Dispatch,
     getState: GetState
 ): boolean => {
-    const { initialPathname } = getState().wallet;
-    if (typeof initialPathname !== 'string') return false;
-
     // DEVICE.CONNECT race condition, "selectDevice" method was called but currently selectedDevice is in getState (auth) process
     // if so, consume this action (return true) to break "selectDevice" process
     const { selectedDevice } = getState().wallet;
-    if (
-        selectedDevice &&
-        selectedDevice.type === 'acquired' &&
-        !selectedDevice.features.passphrase_protection &&
-        !selectedDevice.state
-    )
-        return true;
+    if (selectedDevice && selectedDevice.type === 'acquired' && !selectedDevice.state) return true;
+
+    const { initialPathname } = getState().wallet;
+    if (typeof initialPathname !== 'string') return false;
 
     const valid = dispatch(
         getValidUrl({

--- a/src/actions/WalletActions.js
+++ b/src/actions/WalletActions.js
@@ -23,7 +23,7 @@ export type WalletAction =
     | {
           type: typeof WALLET.SET_INITIAL_URL,
           state?: RouterLocationState,
-          pathname?: ?string,
+          pathname?: string,
       }
     | {
           type: typeof WALLET.TOGGLE_DEVICE_DROPDOWN,

--- a/src/actions/WalletActions.js
+++ b/src/actions/WalletActions.js
@@ -23,7 +23,7 @@ export type WalletAction =
     | {
           type: typeof WALLET.SET_INITIAL_URL,
           state?: RouterLocationState,
-          pathname?: string,
+          pathname?: ?string,
       }
     | {
           type: typeof WALLET.TOGGLE_DEVICE_DROPDOWN,

--- a/src/actions/WalletActions.js
+++ b/src/actions/WalletActions.js
@@ -169,15 +169,11 @@ export const observe = (prevState: State, action: Action): PayloadAction<boolean
 
     const state: State = getState();
 
-    const locationChanged = reducerUtils.observeChanges(
-        prevState.router.location,
-        state.router.location
-    );
     const device = reducerUtils.getSelectedDevice(state);
     const selectedDeviceChanged = reducerUtils.observeChanges(state.wallet.selectedDevice, device);
 
     // handle devices state change (from trezor-connect events or location change)
-    if (locationChanged || selectedDeviceChanged) {
+    if (selectedDeviceChanged) {
         if (device && deviceUtils.isSelectedDevice(state.wallet.selectedDevice, device)) {
             dispatch({
                 type: WALLET.UPDATE_SELECTED_DEVICE,

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -32,12 +32,13 @@ const WalletService: Middleware = (api: MiddlewareAPI) => (next: MiddlewareDispa
         // exclude landing page url
         const { pathname } = action.payload.location;
         const isValidPath = !api.dispatch(RouterActions.isLandingPageUrl(pathname, true));
-        api.dispatch({
-            type: WALLET.SET_INITIAL_URL,
-            pathname: isValidPath ? pathname : null,
-            state: {},
-        });
-
+        if (isValidPath) {
+            api.dispatch({
+                type: WALLET.SET_INITIAL_URL,
+                pathname,
+                state: {},
+            });
+        }
         // pass action and break process
         return next(action);
     }
@@ -46,10 +47,8 @@ const WalletService: Middleware = (api: MiddlewareAPI) => (next: MiddlewareDispa
     next(action);
 
     switch (action.type) {
-        case WALLET.SET_INITIAL_URL:
-            if (action.hasOwnProperty('pathname')) {
-                api.dispatch(LocalStorageActions.loadData());
-            }
+        case WALLET.SET_FIRST_LOCATION_CHANGE:
+            api.dispatch(LocalStorageActions.loadData());
             break;
         case WALLET.SET_SELECTED_DEVICE:
             // try to authorize device

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -32,13 +32,12 @@ const WalletService: Middleware = (api: MiddlewareAPI) => (next: MiddlewareDispa
         // exclude landing page url
         const { pathname } = action.payload.location;
         const isValidPath = !api.dispatch(RouterActions.isLandingPageUrl(pathname, true));
-        if (isValidPath) {
-            api.dispatch({
-                type: WALLET.SET_INITIAL_URL,
-                pathname: action.payload.location.pathname,
-                state: {},
-            });
-        }
+        api.dispatch({
+            type: WALLET.SET_INITIAL_URL,
+            pathname: isValidPath ? pathname : null,
+            state: {},
+        });
+
         // pass action and break process
         return next(action);
     }
@@ -48,7 +47,7 @@ const WalletService: Middleware = (api: MiddlewareAPI) => (next: MiddlewareDispa
 
     switch (action.type) {
         case WALLET.SET_INITIAL_URL:
-            if (action.pathname) {
+            if (action.hasOwnProperty('pathname')) {
                 api.dispatch(LocalStorageActions.loadData());
             }
             break;

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -29,11 +29,16 @@ const WalletService: Middleware = (api: MiddlewareAPI) => (next: MiddlewareDispa
         api.dispatch(WalletActions.init());
         // set initial url
         // TODO: validate if initial url is potentially correct
-        api.dispatch({
-            type: WALLET.SET_INITIAL_URL,
-            pathname: action.payload.location.pathname,
-            state: {},
-        });
+        // exclude landing page url
+        const { pathname } = action.payload.location;
+        const isValidPath = !api.dispatch(RouterActions.isLandingPageUrl(pathname, true));
+        if (isValidPath) {
+            api.dispatch({
+                type: WALLET.SET_INITIAL_URL,
+                pathname: action.payload.location.pathname,
+                state: {},
+            });
+        }
         // pass action and break process
         return next(action);
     }
@@ -62,6 +67,29 @@ const WalletService: Middleware = (api: MiddlewareAPI) => (next: MiddlewareDispa
 
     // update common values ONLY if application is ready
     if (!api.getState().wallet.ready) return action;
+
+    // observe common values in WallerReducer
+    if (!(await api.dispatch(WalletActions.observe(prevState, action)))) {
+        // if "selectedDevice" didn't change observe common values in SelectedAccountReducer
+        if (!(await api.dispatch(SelectedAccountActions.observe(prevState, action)))) {
+            // if "selectedAccount" didn't change observe send form props changes
+            api.dispatch(SendFormActions.observe(prevState, action));
+        }
+    } else {
+        // no changes in common values
+        if (action.type === CONNECT.RECEIVE_WALLET_TYPE) {
+            if (action.device.state) {
+                // redirect to root view (Dashboard) if device was authenticated before
+                api.dispatch(RouterActions.selectFirstAvailableDevice(true));
+            }
+            api.dispatch(TrezorConnectActions.authorizeDevice());
+        }
+        if (action.type === CONNECT.AUTH_DEVICE) {
+            // selected device did changed
+            // try to restore discovery after device authentication
+            api.dispatch(DiscoveryActions.restore());
+        }
+    }
 
     // double verification needed
     // Corner case: LOCATION_CHANGE was called but pathname didn't changed (redirection from RouterService)
@@ -94,29 +122,6 @@ const WalletService: Middleware = (api: MiddlewareAPI) => (next: MiddlewareDispa
 
         // clear notifications
         api.dispatch(NotificationActions.clear(prevLocation.state, currentLocation.state));
-    }
-
-    // observe common values in WallerReducer
-    if (!(await api.dispatch(WalletActions.observe(prevState, action)))) {
-        // if "selectedDevice" didn't change observe common values in SelectedAccountReducer
-        if (!(await api.dispatch(SelectedAccountActions.observe(prevState, action)))) {
-            // if "selectedAccount" didn't change observe send form props changes
-            api.dispatch(SendFormActions.observe(prevState, action));
-        }
-    } else {
-        // no changes in common values
-        if (action.type === CONNECT.RECEIVE_WALLET_TYPE) {
-            if (action.device.state) {
-                // redirect to root view (Dashboard) if device was authenticated before
-                api.dispatch(RouterActions.selectFirstAvailableDevice(true));
-            }
-            api.dispatch(TrezorConnectActions.authorizeDevice());
-        }
-        if (action.type === CONNECT.AUTH_DEVICE) {
-            // selected device did changed
-            // try to restore discovery after device authentication
-            api.dispatch(DiscoveryActions.restore());
-        }
     }
 
     // even if "selectedDevice" didn't change because it was updated on DEVICE.CHANGED before DEVICE.CONNECT action


### PR DESCRIPTION
- Do not set initialUrl if it is landingPage
- Block "RouterAction.selectDevice" if currently selected device is in auth process
- Move WalletActions.observe() before DiscoveryActions.restore() in "WalletSerivce"