### PR TITLE
Feature/auto reconnect to the backend

### DIFF
--- a/src/actions/BlockchainActions.js
+++ b/src/actions/BlockchainActions.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as BLOCKCHAIN from 'actions/constants/blockchain';
+import * as DiscoveryActions from 'actions/DiscoveryActions';
 import * as EthereumBlockchainActions from 'actions/ethereum/BlockchainActions';
 import * as RippleBlockchainActions from 'actions/ripple/BlockchainActions';
 
@@ -18,6 +19,10 @@ export type BlockchainAction =
       }
     | {
           type: typeof BLOCKCHAIN.START_SUBSCRIBE,
+          shortcut: string,
+      }
+    | {
+          type: typeof BLOCKCHAIN.FAIL_SUBSCRIBE,
           shortcut: string,
       };
 
@@ -128,6 +133,8 @@ export const onError = (
     const network = config.networks.find(c => c.shortcut === shortcut);
     if (!network) return;
 
+    dispatch(autoReconnect(shortcut));
+
     switch (network.type) {
         case 'ethereum':
             await dispatch(EthereumBlockchainActions.onError(shortcut));
@@ -138,5 +145,30 @@ export const onError = (
             break;
         default:
             break;
+    }
+};
+
+const autoReconnect = (shortcut: string): PromiseAction<void> => async (
+    dispatch: Dispatch,
+    getState: GetState
+): Promise<void> => {
+    const MAX_ATTEMPTS = 4;
+    let blockchain = getState().blockchain.find(b => b.shortcut === shortcut);
+    // try to automatically reconnect and wait after each attemp (5s * #attempt) untill max number of attemps is reached
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+        const waitTime = 5000 * (i + 1); /// 5s * #attempt
+        if (!blockchain || blockchain.connected) {
+            break;
+        }
+
+        blockchain = getState().blockchain.find(b => b.shortcut === shortcut);
+
+        // reconnect with 7s timeout
+        // eslint-disable-next-line no-await-in-loop
+        await dispatch(DiscoveryActions.reconnect(shortcut, 7000));
+
+        // wait before next try
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(resolve, waitTime));
     }
 };

--- a/src/actions/constants/blockchain.js
+++ b/src/actions/constants/blockchain.js
@@ -1,5 +1,6 @@
 /* @flow */
 
 export const START_SUBSCRIBE: 'blockchain__start_subscribe' = 'blockchain__start_subscribe';
+export const FAIL_SUBSCRIBE: 'blockchain__fail_subscribe' = 'blockchain__fail_subscribe';
 export const READY: 'blockchain__ready' = 'blockchain__ready';
 export const UPDATE_FEE: 'blockchain__update_fee' = 'blockchain__update_fee';

--- a/src/reducers/BlockchainReducer.js
+++ b/src/reducers/BlockchainReducer.js
@@ -48,6 +48,30 @@ const onStartSubscribe = (state: State, shortcut: string): State => {
     ]);
 };
 
+const onFailSubscribe = (state: State, shortcut: string): State => {
+    const network = state.find(b => b.shortcut === shortcut);
+    if (network) {
+        const others = state.filter(b => b !== network);
+        return others.concat([
+            {
+                ...network,
+                connecting: false,
+            },
+        ]);
+    }
+
+    return state.concat([
+        {
+            shortcut,
+            connected: false,
+            connecting: false,
+            block: 0,
+            feeTimestamp: 0,
+            feeLevels: [],
+        },
+    ]);
+};
+
 const onConnect = (state: State, action: BlockchainConnect): State => {
     const shortcut = action.payload.coin.shortcut.toLowerCase();
     const network = state.find(b => b.shortcut === shortcut);
@@ -136,6 +160,8 @@ export default (state: State = initialState, action: Action): State => {
     switch (action.type) {
         case BLOCKCHAIN_ACTION.START_SUBSCRIBE:
             return onStartSubscribe(state, action.shortcut);
+        case BLOCKCHAIN_ACTION.FAIL_SUBSCRIBE:
+            return onFailSubscribe(state, action.shortcut);
         case BLOCKCHAIN_EVENT.CONNECT:
             return onConnect(state, action);
         case BLOCKCHAIN_EVENT.ERROR:


### PR DESCRIPTION
When trezor-connect returns `BLOCKCHAIN.ERROR` event (eg in case of lost connection to backends) a function `BlockchainActions.onError` is dispatched. Inside this `onError` function newly added func `autoReconnect` is dispatched.

In a loop it waits for `DiscoveryActions.reconnect` with 7s timeout, (`reconnect` now accepts timeout as a second parameter). Then it waits for a dummy timeout (5s* #attempt (0-indexed)) before running the next iteration. After 4 attemps (1 instant and 3 delayed) it gives up.

closes https://github.com/trezor/trezor-wallet/issues/523