### PR TITLE
Expand allowable message size for SignVerify to be 1024

### DIFF
--- a/src/views/Wallet/views/Account/SignVerify/index.js
+++ b/src/views/Wallet/views/Account/SignVerify/index.js
@@ -119,7 +119,7 @@ class SignVerify extends Component<Props> {
                                 onChange={this.handleInputChange}
                                 rows={4}
                                 maxRows={4}
-                                maxLength={255}
+                                maxLength={1024}
                             />
                         </Row>
                         <Row>
@@ -172,7 +172,7 @@ class SignVerify extends Component<Props> {
                                 onChange={this.handleInputChange}
                                 rows={4}
                                 maxRows={4}
-                                maxLength={255}
+                                maxLength={1024}
                             />
                         </Row>
                         <Row>


### PR DESCRIPTION
The current trezor FW seems to support signing of messages up to 1024 bytes yet the TextInput for the message signing page limits the input to 255.  Consider expanding to 1024.

Code snippet signing a 1024 byte message below.

The current trezor FW seems to support signing of messages up to 1024 bytes yet the TextInput for the message signing page limits the input to 255.  Consider expanding to 1024.

Code snippet signing a 1024 byte message below.

<details>
<summary>sign_verify_1024.py</summary>
<pre>from trezorlib.ui import ClickUI
from trezorlib.btc import sign_message
from trezorlib.tools import parse_path
from trezorlib.client import TrezorClient
from trezorlib.transport import get_transport
from base64 import b64encode

device = get_transport()
ui = ClickUI()
client = TrezorClient(transport=device, ui=ui)

msg= """0 2 4 6 8 10 13 16 19 22 25 28 31 34 37 40
43 46 49 52 55 58 61 64 67 70 73 76 79 82 85 88 91
94 97 100 104 108 112 116 120 124 128 132 136 140
144 148 152 156 160 164 168 172 176 180 184 188 192
196 200 204 208 212 216 220 224 228 232 236 240 244
248 252 256 260 264 268 272 276 280 284 288 292 296
300 304 308 312 316 320 324 328 332 336 340 344 348
352 356 360 364 368 372 376 380 384 388 392 396 400
404 408 412 416 420 424 428 432 436 440 444 448 452
456 460 464 468 472 476 480 484 488 492 496 500 504
508 512 516 520 524 528 532 536 540 544 548 552 556
560 564 568 572 576 580 584 588 592 596 600 604 608
612 616 620 624 628 632 636 640 644 648 652 656 660
664 668 672 676 680 684 688 692 696 700 704 708 712
716 720 724 728 732 736 740 744 748 752 756 760 764
768 772 776 780 784 788 792 796 800 804 808 812 816
820 824 828 832 836 840 844 848 852 856 860 864 868
872 876 880 884 888 892 896 900 904 908 912 916 920
924 928 932 936 940 944 948 952 956 960 964 968 972
976 980 984 988 992 996 1000 1005 1010 1015 1020"""

path = parse_path("m/44'/0'/0'/0/0")
resp = sign_message(client, "Bitcoin", path, msg)
b64text = b64encode(resp.signature).decode()

print("address:", resp.address)
print("signature:", b64text)
print("message_len:", len(msg))
</pre>
</details>