### PR TITLE
Bump-up Node.js to 10.x LTS in Dockerfile.test

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,7 +4,7 @@ FROM python:latest
 # setup
 #
 RUN apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl --proto '=https' --tlsv1.2 -sSf https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y chromium libappindicator3-1 xdg-utils fonts-liberation nodejs wget dpkg git python python3 python3-pip xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 RUN npm install -g yarn
 


### PR DESCRIPTION
Dockerfile.test won't build, this makes it harder for outside developers to contribute and test new features. Besides `Dockerfile` is already using `node:10.15.1`.

### Unsupported version of Node.js is being used

When building `Dockerfile.test`, build warning is received about Node.js 8.x not being supported anymore.

```
                              DEPRECATION WARNING

  Node.js 8.x LTS Carbon is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_10.x — Node.js 10 LTS "Dubnium" (recommended)
   * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"

  Please see https://github.com/nodejs/Release for details about which
  version may be appropriate for you.

  The NodeSource Node.js distributions repository contains
  information both about supported versions of Node.js and supported Linux
  distributions. To learn more about usage, see the repository:
    https://github.com/nodesource/distributions
```

**Use of the old Node.js version makes step `RUN npm install -g yarn` subsequently fail**
```
Step 5/27 : RUN npm install -g yarn
 ---> Running in 54d47d7bc753
/bin/sh: 1: npm: not found
```

**Problem**: `npm` needs to be installed separately when using Node.js 8.x release, because `python:latest` Docker image already has greater version of Node.js in it's repositories, but this version does not depend on `npm`. Please also note that version of `npm` bundled with `python:latest` Docker image does not support bundled version of `Node.js v10.15.2`. 

```
Step 4/26 : RUN npm install -g yarn
---> Running in c7652417c705
npm WARN npm npm does not support Node.js v10.15.2
npm WARN npm You should probably upgrade to a newer version of node as we
npm WARN npm can't make any promises that npm will work with this version.
npm WARN npm Supported releases of Node.js are the latest release of 4, 6, 7, 8, 9.
npm WARN npm You can find the latest version at https://nodejs.org/
```

Version `10.19.0-1nodesource1` from Node.js repositories is supported.

**Solution**: Bump up version of Node.js to 10 LTS 
```
# Prevent from TLS downgrade attack, sever does not support TLS 1.3
RUN curl --proto '=https' --tlsv1.2 -sSf https://deb.nodesource.com/setup_10.x | bash -
```